### PR TITLE
Make left and right skate rotations configurable

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -14,13 +14,15 @@ namespace ModelReplacement
     public class Plugin : BaseUnityPlugin
     {
         public static ConfigEntry<int> configCharacterToReplace;
-        public static ConfigEntry<Vector3> inlineSkatesRot;
+        public static ConfigEntry<Vector3> inlineSkatesRotL;
+        public static ConfigEntry<Vector3> inlineSkatesRotR;
         public static ConfigEntry<bool> configOverwriteShader;
 
         private void Awake()
         {
             configCharacterToReplace = Config.Bind("General", "charaToReplace", -1, "Which character to replace, taken from the 'Characters' enum. See this image (The numbers are one digit more than they should be, so what would be 2 in this image is actually 1, 3 is 2, 4 is 3, and so on): https://files.catbox.moe/vhda8a.png");
-            inlineSkatesRot = Config.Bind("General", "inlineSkatesDir", Vector3.zero, "The rotation of inline skates in angles. Modify this to make your skates look correct");
+            inlineSkatesRotL = Config.Bind("General", "inlineSkatesDirL", Vector3.zero, "The rotation of the left inline skate in angles. Modify this to make your left skate look correct");
+            inlineSkatesRotR = Config.Bind("General", "inlineSkatesDirR", Vector3.zero, "The rotation of the right inline skate in angles. Modify this to make your right skate look correct");
             configOverwriteShader = Config.Bind("General", "shaderOverwritten", false, "Whether or not we prioritize the shader you set to your material in the Unity editor or the base shader the game uses for outlines and cel-shading");
 
             SavedVariables.charaPrefab = SavedVariables.GetBundle().LoadAsset<GameObject>("Chara");
@@ -120,8 +122,8 @@ namespace ModelReplacement
         static void Postfix(CharacterVisual.MoveStylePropMode mode, PlayerMoveStyleProps ___moveStyleProps, CharacterVisual __instance){
             
             if(mode == CharacterVisual.MoveStylePropMode.ACTIVE && __instance.transform.GetChild(0).name.Contains("Chara")){
-                ___moveStyleProps.skateL.transform.localRotation = Quaternion.Euler(Plugin.inlineSkatesRot.Value);
-                ___moveStyleProps.skateR.transform.localRotation = Quaternion.Euler(Plugin.inlineSkatesRot.Value);
+                ___moveStyleProps.skateL.transform.localRotation = Quaternion.Euler(Plugin.inlineSkatesRotL.Value);
+                ___moveStyleProps.skateR.transform.localRotation = Quaternion.Euler(Plugin.inlineSkatesRotR.Value);
             }
         }
 


### PR DESCRIPTION
Allows each inline skate to have their rotation adjusted, for models where the single rotation value only worked with one of the skates.

Before:
![2023-08-27_17-55-58_Bomb_Rush_Cyberfunk](https://github.com/TheSmallBlue/BRC-ModelReplacement/assets/15317421/e76ff7b8-df25-436d-8288-b4bab737498b)
After:
![2023-08-27_18-09-29_Bomb_Rush_Cyberfunk](https://github.com/TheSmallBlue/BRC-ModelReplacement/assets/15317421/bb1b56d5-574f-4b84-84d1-38ba1bc805ce)
